### PR TITLE
update lodash@4.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function processPatterns(patterns, fn) {
   // Filepaths to return.
   var result = [];
   // Iterate over flattened patterns array.
-  _.flatten(patterns).forEach(function(pattern) {
+  _.flattenDeep(patterns).forEach(function(pattern) {
     // If the first character is ! it should be omitted
     var exclusion = pattern.indexOf('!') === 0;
     // If the pattern is an exclusion, remove the !

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "mkdirp": "^0.3.5",
     "iconv-lite": "^0.2.10",
-    "lodash": "^1.2.1",
+    "lodash": "^4",
     "glob": "^4.0.4",
     "rimraf": "^2.1.4"
   },


### PR DESCRIPTION
`npm i fs-sync` WARNs me about old lodash is using under hood. I've updated lodash to `^4`. The only difference is in using `flattenDeep()` instead of `flatten(… isShallow = false)`. `_.difference` and `_.union` seemes compatible.

Sadly, there's no tests that covers that.